### PR TITLE
fix duplicate symbols error on clang 11+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,20 @@
 # size -m mach_kernel
 #
 #
+# get OS type from shell
+OSTYPE  = $(shell uname)
+#
 ARCH	= i386
+# if Linux, attempt to use osxcross with clang; otherwise use cc on osx (will not build on 10.15 or later)
+ifeq ($(OSTYPE), Linux)
+	CC  := i386-apple-darwin8-clang
+	LD  := i386-apple-darwin8-ld
+	LDFLAGS =
+else
+	CC  := cc
+	LD  := ld
+endif
 
-CC  := /usr/bin/gcc
-LD  := /usr/bin/ld
-LDFLAGS =
 
 # start.o must be 1st in the link order (ld below)
 OBJ	= start.o vsprintf.o console.o utils.o elilo_code.o darwin_code.o linux_code.o boot_loader.o

--- a/README
+++ b/README
@@ -1,9 +1,6 @@
 modifying to compile with
-Apple LLVM version 10.0.0 (clang-1000.11.45.5)
+Apple LLVM version 15.0.0 (clang-15.0.2-1)
 
-
-
- 
 atv-bootloader (March 10 2008)
 
 This bootloader works by embedding a Linux kernel/initrd into "mach kernel" that boot.efi loads. Right now it's very simplistic and will boot to login prompt. user = root, password = root. parted is present as well as hfsplus tools for creating gpt partitions and formating them as ext2/3 and hfs/hfsplus. Also present is kexec to bootload another kernel. Typical usage is;

--- a/boot_loader.c
+++ b/boot_loader.c
@@ -54,6 +54,12 @@ mach_boot_parms *mach_bp;
 #define KERNEL_RESERVE_SIZE 0x00400000
 #define BOOT_PARAM_MEMSIZE  0x00004000	// 16384
 /**********************************************************************/
+
+volatile CURRENT_VIDEO_MODE_DETAILS vmode;
+volatile uint32_t VIDEO_CURSOR_POSY;
+volatile uint32_t VIDEO_CURSOR_POSX;
+volatile uint32_t VIDEO_ATTR;
+
 void load_linux(unsigned int args)
 {
 	int           i;

--- a/console.c
+++ b/console.c
@@ -17,6 +17,11 @@
 
 extern int vsprintf(char *buf, const char *fmt, va_list args);
 
+extern volatile CURRENT_VIDEO_MODE_DETAILS vmode;
+extern volatile uint32_t VIDEO_CURSOR_POSY;
+extern volatile uint32_t VIDEO_CURSOR_POSX;
+extern volatile uint32_t VIDEO_ATTR;
+
 const unsigned short waStarts[] = {
  0, 4, 12, 20, 29, 42, 53, 56, // <-- (
  62, 67, 73, 81, 85, 91, 95, 100, // <-- 0

--- a/types.h
+++ b/types.h
@@ -45,10 +45,4 @@ typedef struct {
 	u32 xmargin;
 } CURRENT_VIDEO_MODE_DETAILS;
 
-volatile CURRENT_VIDEO_MODE_DETAILS vmode;
-
-volatile uint32_t VIDEO_CURSOR_POSY;
-volatile uint32_t VIDEO_CURSOR_POSX;
-volatile uint32_t VIDEO_ATTR;
-
 #endif


### PR DESCRIPTION
Allows for supporting more modern versions of clang either through [osxcross](https://github.com/tpoechtrager/osxcross) with the 10.4 api  on Linux or on later versions of Mac OS (they might need the 10.4 api as well). Does not affect Clang 10 builds in any way.